### PR TITLE
update to point to local mirror of buildroot.net

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "buildroot"]
 	path = buildroot
-	url = git://git.buildroot.net/buildroot
+	url = git://github.com/opennetworklinux/buildroot-mirror


### PR DESCRIPTION
Updated to point to the mirror of buildroot so that we can update buildroot as necessary to work with newer gcc, etc.
